### PR TITLE
Option to set consul agent host.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ discovery:
     tag:  OPTIONAL_TAG_TO_FILTER_NODES
     ws-port:  OPTIONAL_TO_SPECIFY_HTTP_API_PORT_FOR_CONSUL_DEFAULT_IS_8500
     ws-host:  OPTIONAL_TO_SPECIFY_HTTP_API_HOST_FOR_CONSUL_DEFAULT_IS_LOCALHOST
+    local-ws-port:  DEPRECATED_OPTIONAL_TO_SPECIFY_LOCAL_HTTP_API_PORT_FOR_CONSUL_DEFAULT_IS_8500
 
 
 ```
@@ -25,7 +26,7 @@ Key|Example|Description
 `discovery.consul.tag`|`searcher`| **Optional** parameter `tag` to filter nodes registered for given service names, [read more..](https://www.consul.io/docs/agent/services.html)
 `discovery.consul.ws-port`|`8500`|**Optional** parameter to specify the port of the consul REST endpoint. **default** value is `8500` [read more...] (https://www.consul.io/docs/agent/options.html#http_port)
 `discovery.consul.ws-host`|`localhost`|**Optional** parameter to specify the hostname of the consul REST endpoint. **default** value is `localhost` [read more...] (https://www.consul.io/docs/agent/options.html#_bind)
-
+`discovery.consul.local-ws-port`|`8500`|**Deprecated** parameter to specify the rest web end point's port on localhost for consul. **default** value is `8500` [read more...] (https://www.consul.io/docs/agent/options.html#http_port)
 
 This plugin is based on https://github.com/grantr/elasticsearch-srv-discovery and
 modified to be based on consul API calls instead of DNS records.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ discovery:
   consul:
     service-names: ["CONSUL_SERVICE_NAME1", "CONSUL_SERVICE_NAME2"]
     tag:  OPTIONAL_TAG_TO_FILTER_NODES
-    local-ws-port:  OPTIONAL_TO_SPECIFY_LOCAL_HTTP_API_PORT_FOR_CONSUL_DEFAULT_IS_8500
+    ws-port:  OPTIONAL_TO_SPECIFY_HTTP_API_PORT_FOR_CONSUL_DEFAULT_IS_8500
+    ws-host:  OPTIONAL_TO_SPECIFY_HTTP_API_HOST_FOR_CONSUL_DEFAULT_IS_LOCALHOST
 
 
 ```
@@ -22,7 +23,8 @@ Key|Example|Description
 ---|---|---
 `discovery.consul.service-names`|`es-dc01-teamA-cluster01-data-nodes`| an array of service names those are registered in consul
 `discovery.consul.tag`|`searcher`| **Optional** parameter `tag` to filter nodes registered for given service names, [read more..](https://www.consul.io/docs/agent/services.html)
-`discovery.consul.local-ws-port`|`8500`|**Optional** parameter to specify the rest web end point's port on localhost for consul. **default** value is `8500` [read more...] (https://www.consul.io/docs/agent/options.html#http_port)
+`discovery.consul.ws-port`|`8500`|**Optional** parameter to specify the port of the consul REST endpoint. **default** value is `8500` [read more...] (https://www.consul.io/docs/agent/options.html#http_port)
+`discovery.consul.ws-host`|`localhost`|**Optional** parameter to specify the hostname of the consul REST endpoint. **default** value is `localhost` [read more...] (https://www.consul.io/docs/agent/options.html#_bind)
 
 
 This plugin is based on https://github.com/grantr/elasticsearch-srv-discovery and

--- a/src/main/java/org/elasticsearch/discovery/consul/ConsulUnicastHostsProvider.java
+++ b/src/main/java/org/elasticsearch/discovery/consul/ConsulUnicastHostsProvider.java
@@ -70,7 +70,8 @@ public class ConsulUnicastHostsProvider extends AbstractComponent implements Uni
 	private final TransportService transportService;
 	private final Version version;
 	private final Set<String> consulServiceNames;
-	private final int consulAgentLocalWebServicePort;
+	private final int consulAgentWebServicePort;
+	private final String consulAgentWebServiceHost;
 	private final String tag;
 
 	@Inject
@@ -85,8 +86,11 @@ public class ConsulUnicastHostsProvider extends AbstractComponent implements Uni
 		for (String serviceName : serviceNamesArray) {
 			this.consulServiceNames.add(serviceName);
 		}
-		this.consulAgentLocalWebServicePort = settings.getAsInt("discovery.consul" +
-				".local-ws-port", 8500);
+
+		this.consulAgentWebServiceHost = settings.get("discovery.consul" +
+				".ws-host", "localhost");
+		this.consulAgentWebServicePort = settings.getAsInt("discovery.consul" +
+				".ws-port", 8500);
 		this.tag = settings.get("discovery.consul.tag");
 	}
 
@@ -99,7 +103,7 @@ public class ConsulUnicastHostsProvider extends AbstractComponent implements Uni
 		Set<DiscoveryResult> consulDiscoveryResults = null;
 		try {
 			consulDiscoveryResults = new ConsulService(this
-					.consulAgentLocalWebServicePort, this.tag)
+					.consulAgentWebServicePort, this.consulAgentWebServiceHost, this.tag)
 					.discoverHealthyNodes(this.consulServiceNames);
 			if (logger.isTraceEnabled()) {
 				logger.trace("discovered {} nodes", (consulDiscoveryResults != null ?

--- a/src/main/java/org/elasticsearch/discovery/consul/ConsulUnicastHostsProvider.java
+++ b/src/main/java/org/elasticsearch/discovery/consul/ConsulUnicastHostsProvider.java
@@ -81,6 +81,7 @@ public class ConsulUnicastHostsProvider extends AbstractComponent implements Uni
 		this.transportService = transportService;
 		this.version = version;
 		this.consulServiceNames = new HashSet<>();
+		int localWsPort = -1;
 
 		final String[] serviceNamesArray = settings.getAsArray("discovery.consul.service-names");
 		for (String serviceName : serviceNamesArray) {
@@ -91,6 +92,15 @@ public class ConsulUnicastHostsProvider extends AbstractComponent implements Uni
 				".ws-host", "localhost");
 		this.consulAgentWebServicePort = settings.getAsInt("discovery.consul" +
 				".ws-port", 8500);
+
+		localWsPort = settings.getAsInt("discovery.consul" +
+				".local-ws-port", -1);
+		if (localWsPort != -1) {
+			logger.warn("Using discovey.consul.local-ws-port is deprecated. " +
+				"Prefer discovey.consul.ws-port.");
+			this.consulAgentWebServicePort = localWsPort;
+		}
+
 		this.tag = settings.get("discovery.consul.tag");
 	}
 


### PR DESCRIPTION
* Option added to specify a custom consul agent host.
* Use consul service host:port for node discovery over consul agent host.  

Related to #7 but fixes on `1.x` branch.

Use case: 
Dockerized elastic deployments where consul agent runs on the docker host.